### PR TITLE
Added .env file so that app can be invoked from cli

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=${PYTHONPATH}:weather


### PR DESCRIPTION
Now 'ModuleNotFoundError' will not be thrown if the application is invoked by 'pipenv run python weather'.